### PR TITLE
bugfix: incorrect dockerfile #1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,3 @@ RUN npm install --frozen-lockfile
 COPY . .
 
 RUN npm run build
-
-EXPOSE 3000
-
-CMD ["npm", "run", "start"]


### PR DESCRIPTION
-remove EXPOSE 3000 because it is not needed
-remove npm run start because it is incompatible with vite